### PR TITLE
fix: use unscoped package name and NPM_TOKEN for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Publish package to npm
         run: npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Generate checksums
         run: |

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lusha-org/n8n-nodes-lusha",
+  "name": "n8n-nodes-lusha",
   "version": "1.2.0",
   "description": "Complete Lusha API integration for n8n with contact enrichment, company enrichment, and prospecting capabilities",
   "keywords": [


### PR DESCRIPTION
## Summary
- Renames package from `@lusha-org/n8n-nodes-lusha` → `n8n-nodes-lusha` so it appears in n8n's community node installer (requires npmjs.com, unscoped)
- Switches CI secret from `NPM_ORG_TOKEN` → `NPM_TOKEN` (the automation token already added to repo secrets)

## Why this was failing
The previous publish job hit a 404 because the scoped name `@lusha-org/n8n-nodes-lusha` requires npm org membership that wasn't available via the token.

## Test plan
- [ ] Merge this PR → CI triggers on push to `main`
- [ ] Verify the `publish-npm` job succeeds in GitHub Actions
- [ ] Confirm `n8n-nodes-lusha` appears on https://www.npmjs.com/package/n8n-nodes-lusha

🤖 Generated with [Claude Code](https://claude.com/claude-code)